### PR TITLE
Implement hashicorp binary installer role for ansible galaxy

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2019 Crown Copyright (Companies House)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Requirements
 ------------
 
 - [GnuPG](https://gnupg.org/) installed on the host(s) that the role will run against
-  - HashiCorp's [public key](https://www.hashicorp.com/security) imported into the GnuPG keyring
+- HashiCorp's [public key](https://www.hashicorp.com/security) imported into the GnuPG keyring
 
 Role Variables
 --------------

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
-# ansible-role-hashicorp-binary
-An Ansible Galaxy role for installing one or more HashiCorp tools from binary distribution packages
+Ansible Role: HashiCorp Binary Installer
+========================================
+
+An [Ansible Galaxy](https://galaxy.ansible.com/) role for installing one or more [HashiCorp](https://www.hashicorp.com/) tools from binary distribution packages. Signature verification is used to ensure files have not been tampered with. 
+
+Requirements
+------------
+
+- [GnuPG](https://gnupg.org/) installed on the host(s) that the role will run against
+  - HashiCorp's [public key](https://www.hashicorp.com/security) imported into the GnuPG keyring
+
+Role Variables
+--------------
+
+Variable           | Default        | Description
+-------------------|----------------|-------------
+`hashicorp_tools`  | *None*         | A list of dictionaries defining one or more tools to be installed. Each dictionary should include a `name` and `version` key. Refer to the `supported_tools` variable in this role for a full list of the supported tool names.
+
+For example:
+
+```
+hashicorp_tools:
+  - name: vault, version: 1.0.0
+  - name: consul, version: 1.0.0
+```
+
+Example Requirements File
+-------------------------
+
+```
+- src: https://github.com/companieshouse/ansible-role-hashicorp-binary-installer
+  name: hashicorp
+```
+
+License
+-------
+
+MIT
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,14 @@
+galaxy_info:
+  author: Companies House
+  description: Install HashiCorp tools from binary distribution packages
+  license: MIT
+
+  min_ansible_version: 2.7.9
+
+  platforms:
+    - name: centos
+      versions:
+        - 7
+
+dependencies: []
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,0 +1,89 @@
+---
+
+- fail: 
+    msg: "The specified tool '{{ tool.name }}' is unsupported by this Ansible Galaxy role"
+  when: tool.name not in supported_tools
+
+- set_fact:
+    pretty_name: "{{ tool.name|capitalize }}"
+
+- name: Create temporary directory
+  tempfile:
+    state: directory
+    suffix: build
+  register: temp_dir
+
+- name: "Download {{ pretty_name }} binary zip, SHASUM, and SHASUM.sig files"
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ temp_dir.path }}"
+    mode: 0600
+  with_items:
+    - "{{ release_url }}/{{ tool.name }}/{{ tool.version }}/{{ tool.name }}_{{ tool.version }}_linux_amd64.zip"
+    - "{{ release_url }}/{{ tool.name }}/{{ tool.version }}/{{ tool.name }}_{{ tool.version }}_SHA256SUMS"
+    - "{{ release_url }}/{{ tool.name }}/{{ tool.version }}/{{ tool.name }}_{{ tool.version }}_SHA256SUMS.sig"
+
+- name: Verify the signature file is untampered
+  command: "gpg --verify {{ temp_dir.path }}/{{ tool.name }}_{{ tool.version }}_SHA256SUMS.sig {{ temp_dir.path }}/{{ tool.name }}_{{ tool.version }}_SHA256SUMS"
+  register: signature_check
+
+- name: Assert that signature verification succeeded
+  assert:
+    that:
+      - signature_check.rc == 0
+    fail_msg: "Signature verification failed; file is untrustworthy!"
+    success_msg: "Signature verification succeeded"
+
+- name: "Read expected sha256 checksum for {{ pretty_name }} version binary"
+  shell: "cat {{ temp_dir.path }}/{{ tool.name }}_{{ tool.version }}_SHA256SUMS | grep {{ tool.name }}_{{ tool.version }}_linux_amd64.zip"
+  register: expected_checksum
+
+- name: "Assert that expected sha256 checksum for {{ pretty_name }} zip was read correctly"
+  assert:
+    that:
+      - expected_checksum.stdout_lines|length == 1
+    fail_msg: "Unable to read shasum value for {{ pretty_name }} version from shasum file"
+    success_msg: "Read shasum value for {{ pretty_name }} version"
+
+- name: "Generate actual sha256 checksum for {{ pretty_name }} zip"
+  command: "sha256sum {{ tool.name }}_{{ tool.version }}_linux_amd64.zip"
+  args:
+      chdir: "{{ temp_dir.path }}"
+  register: actual_checksum
+
+- name: "Verify actual sha256 checksum for {{ pretty_name }} zip matches expected checksum"
+  assert:
+    that:
+      - expected_checksum.stdout_lines[0] == actual_checksum.stdout_lines[0]
+    fail_msg: "Actual shasum256 checksum for zip file does not match expected checksum"
+    success_msg: "Actual shasum256 checksum for zip file matches expected checksum"
+
+- name: "Unpack {{ pretty_name }} zip"
+  unarchive:
+    remote_src: yes
+    src: "{{ temp_dir.path }}/{{ tool.name }}_{{ tool.version }}_linux_amd64.zip"
+    dest: /usr/local/bin
+
+- stat:
+    path: /usr/local/bin/{{ tool.name }}
+  register: binary
+
+- name: "Assert that {{ pretty_name }} binary was installed to expected path"
+  assert:
+    that:
+      - binary.stat.exists == True
+    fail_msg: "{{ pretty_name }} binary was not found at expected path"
+    success_msg: "{{ pretty_name }} binary installed correctly"
+
+- name: "Set permissions on {{ pretty_name }} binary"
+  file:
+    path: /usr/local/bin/{{ tool.name }}
+    owner: root
+    group: root
+    mode: 0755
+
+- name: Remove temporary directory
+  file:
+    path: temp_dir.path
+    state: absent
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+- include_tasks: install.yml
+  loop: "{{ hashicorp_tools|flatten(levels=1) }}"
+  loop_control:
+    loop_var: tool
+  when: hashicorp_tools is defined and hashicorp_tools|length > 0
+

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,8 @@
+---
+
+supported_tools:
+  - vault
+  - consul
+
+release_url: https://releases.hashicorp.com
+


### PR DESCRIPTION
✨  These changes comprise an implementation of an Ansible Galaxy role for installing HashiCorp tools from binary distribution packages and includes:

* Enforced file-level checksum verification to ensure tamper proof installation (this requires the HashiCorp public key to be imported into the GnuPG keychain as a prerequisite to using the role, and is documented in the `README`)
* Initial support (tested) for `vault` and `consul`, easily extended to support `terraform`, `packer`, and other HashiCorp tools that follow the same distribution methods
* Documented intention of role and its use with a `README` file